### PR TITLE
Add simple auth URL test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Telegram Spotify Bot
+
+## Testing
+
+Run the test suite with [Vitest](https://vitest.dev/):
+
+```bash
+npm test
+```
+
+This command executes all files in the `tests` directory.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "commonjs",
   "scripts": {
     "start": "serverless dev",
-    "deploy": "serverless deploy"
+    "deploy": "serverless deploy",
+    "test": "vitest run"
   },
   "eslintConfig": {
     "extends": "./.eslintrc.ts"
@@ -50,6 +51,8 @@
     "serverless-offline": "^14.4.0",
     "type-fest": "^4.34.1",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.28.0"
+    "typescript-eslint": "^8.28.0",
+    "ts-node": "^10.9.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SpotifyAuthService } from '../src/services/auth';
+
+// Mock environment variables required by env()
+beforeEach(() => {
+  process.env.SPOTIFY_CLIENT_ID = 'test-client-id';
+  process.env.SPOTIFY_CLIENT_SECRET = 'test-secret';
+  process.env.SPOTIFY_REDIRECT_URI = 'https://example.com/callback';
+  process.env.API_GATEWAY_URL = 'https://api.example.com';
+});
+
+describe('SpotifyAuthService', () => {
+  it('createAuthorizeURL includes required params', () => {
+    const { url, authId } = SpotifyAuthService.createAuthorizeURL();
+    const parsed = new URL(url);
+    const params = parsed.searchParams;
+
+    expect(params.get('client_id')).toBe(process.env.SPOTIFY_CLIENT_ID);
+    expect(params.get('redirect_uri')).toBe(
+      `${process.env.API_GATEWAY_URL}/spotify/callback`
+    );
+    expect(params.get('state')).toBe(authId);
+  });
+});


### PR DESCRIPTION
## Summary
- add basic unit test for `SpotifyAuthService.createAuthorizeURL`
- run tests with `vitest`
- document how to run tests in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f45ecde90832c9b83f3b82b84e5bd