### PR TITLE
Fix grammar in output language line

### DIFF
--- a/src/agents/prompts/index.ts
+++ b/src/agents/prompts/index.ts
@@ -19,7 +19,7 @@ export const Prompts = {
 
     <output>
         Your output will be a Telegram message.
-        Always respond in a concise manner. Always response in the user input language.
+        Always respond in a concise manner. Always respond in the user input language.
     </output>
     `,
 


### PR DESCRIPTION
## Summary
- fix grammar in Spotify agent prompt

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f45f67988832c87e8d7d8d6c5f699